### PR TITLE
Update README to indicate competition end

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Practice software architecture - in public.
 # Work Area for Katas
 - First Kata Feb/Mar 2024 with O'Reilly (Architectural Katas)
 - See folder [`Kata-2024`](https://github.com/lynnlangit/architects-who-code/tree/main/Kata-2024) in this repo for solution work
+
+Note: The competition ended Q1 2024.


### PR DESCRIPTION
Updates the README.md to reflect the end of the competition.

- Adds a note to the `README.md` file stating that the competition ended Q1 2024.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lynnlangit/architects-who-code?shareId=baafa266-59a8-4189-908c-e580b70191d8).